### PR TITLE
Fixes in the Wi-Fi slice descriptors

### DIFF
--- a/empower/core/slice.py
+++ b/empower/core/slice.py
@@ -30,8 +30,8 @@ LTE_SLICE_SCHED = {
 }
 
 WIFI_SLICE_SCHED = {
-    'ROUND_ROBIN': 0x00000000,
-    'AIRTIME_FAIRNESS': 0x00000001
+    'DEFICIT_ROUND_ROBIN': 0x00000000,
+    'BITRATE_FAIRNESS': 0x00000001
 }
 
 
@@ -100,7 +100,7 @@ class Slice:
     but some slice parameters are different for the specified nodes.
 
     The scheduler indicates the way the stations are given the resources within
-    a slice. 0 corresponds to a Round Robin policy, 1 to airtime fairness.
+    a slice. 0 corresponds to a Deficit Round Robin policy, 1 to bitrate fairness.
     """
 
     def __init__(self, dscp, tenant, descriptor):
@@ -114,7 +114,7 @@ class Slice:
             'static-properties': {
                 'amsdu_aggregation': False,
                 'quantum': 12000,
-                'scheduler': WIFI_SLICE_SCHED['ROUND_ROBIN']
+                'scheduler': WIFI_SLICE_SCHED['DEFICIT_ROUND_ROBIN']
             },
             'wtps': {}
         }

--- a/empower/lvapp/lvappconnection.py
+++ b/empower/lvapp/lvappconnection.py
@@ -815,19 +815,19 @@ class LVAPPConnection:
         if prop['quantum'] != status.quantum:
             if wtp.addr not in slc.wifi['wtps']:
                 slc.wifi['wtps'][wtp.addr] = {'static-properties': {}}
-                slc.wifi['wtps'][wtp.addr]['static-properties']['quantum'] = status.quantum
+            slc.wifi['wtps'][wtp.addr]['static-properties']['quantum'] = status.quantum
 
         if prop['amsdu_aggregation'] != bool(status.flags.amsdu_aggregation):
 
             if wtp.addr not in slc.wifi['wtps']:
                 slc.wifi['wtps'][wtp.addr] = {'static-properties': {}}
-                slc.wifi['wtps'][wtp.addr]['static-properties']['amsdu_aggregation'] = \
-                    bool(status.flags.amsdu_aggregation)
+            slc.wifi['wtps'][wtp.addr]['static-properties']['amsdu_aggregation'] = \
+                bool(status.flags.amsdu_aggregation)
 
         if prop['scheduler'] != status.scheduler:
             if wtp.addr not in slc.wifi['wtps']:
                 slc.wifi['wtps'][wtp.addr] = {'static-properties': {}}
-                slc.wifi['wtps'][wtp.addr]['static-properties']['scheduler'] = status.scheduler
+            slc.wifi['wtps'][wtp.addr]['static-properties']['scheduler'] = status.scheduler
 
         self.log.info("Slice %s updated", slc)
 

--- a/empower/lvapp/lvappconnection.py
+++ b/empower/lvapp/lvappconnection.py
@@ -802,24 +802,23 @@ class LVAPPConnection:
 
         slc = tenant.slices[dscp]
         prop = slc.wifi['static-properties']
-        spec_prop = slc.wifi['wtps'][wtp.addr]
 
         if prop['quantum'] != status.quantum:
             if wtp.addr not in slc.wifi['wtps']:
-                spec_prop = {'static-properties': {}}
-                spec_prop['static-properties']['quantum'] = status.quantum
+                slc.wifi['wtps'][wtp.addr] = {'static-properties': {}}
+                slc.wifi['wtps'][wtp.addr]['static-properties']['quantum'] = status.quantum
 
         if prop['amsdu_aggregation'] != bool(status.flags.amsdu_aggregation):
 
             if wtp.addr not in slc.wifi['wtps']:
-                spec_prop = {'static-properties': {}}
-                spec_prop['static-properties']['amsdu_aggregation'] = \
+                slc.wifi['wtps'][wtp.addr] = {'static-properties': {}}
+                slc.wifi['wtps'][wtp.addr]['static-properties']['amsdu_aggregation'] = \
                     bool(status.flags.amsdu_aggregation)
 
         if prop['scheduler'] != status.scheduler:
             if wtp.addr not in slc.wifi['wtps']:
-                spec_prop = {'static-properties': {}}
-                spec_prop['static-properties']['scheduler'] = status.scheduler
+                slc.wifi['wtps'][wtp.addr] = {'static-properties': {}}
+                slc.wifi['wtps'][wtp.addr]['static-properties']['scheduler'] = status.scheduler
 
         self.log.info("Slice %s updated", slc)
 


### PR DESCRIPTION
Fixing in the indentation of the slc.wifi['wtps'][wtp.addr]['static-properties'] variable when parsing the WTP descriptors. As it was, the dictionary entry was updated if the key did not exist, hence being it updated just the first time. 