### PR TITLE
Minor fix in disconnection state units

### DIFF
--- a/empower/managers/ranmanager/ranconnection.py
+++ b/empower/managers/ranmanager/ranconnection.py
@@ -127,7 +127,7 @@ class RANConnection:
 
         if self.device and not self.stream.closed():
             timeout = HELLO_PERIOD * 3
-            if (self.device.last_seen_ts + timeout) < time.time():
+            if (self.device.last_seen_ts + (timeout / 1000)) < time.time():
                 self.log.warning('Client inactive %s at %r',
                                  self.device.addr,
                                  self.stream.socket.getpeername())


### PR DESCRIPTION
- Adjustment from seconds to milliseconds in the timeout for detecting the APs disconnection.
Last seen and current time variables were computed in seconds, while timeout was computed in milliseconds, therefore preventing the disconnection of the APs from being detected.