### PR TITLE
Fix HTTP 500 when creating an app called 'test'

### DIFF
--- a/empower/core/walkmodule.py
+++ b/empower/core/walkmodule.py
@@ -27,12 +27,16 @@ def walk_module(package):
 
     pkgs = pkgutil.walk_packages(package.__path__)
 
-    for _, module_name, is_pkg in pkgs:
-
-        __import__(package.__name__ + "." + module_name)
+    for importer, module_name, is_pkg in pkgs:
 
         if not is_pkg:
             continue
+
+        # only import from subfolders of the package
+        if not any(importer.path.startswith(p) for p in package.__path__):
+            continue
+
+        __import__(package.__name__ + "." + module_name)
 
         if not hasattr(package, module_name):
             continue


### PR DESCRIPTION
When creating a dummy application called 'test' (like helloworld2 as described in the [wiki](https://github.com/5g-empower/5g-empower.github.io/wiki/Python-API)), the server fails with HTTP 500:

Create the dummy app with `mkdir -p empower/apps/test; touch empower/apps/test/__init__.py`.

Server log when running `python3 -m empower.unittest.applications` (6 failures):
```
2020-03-23 08:54:50,585 - tornado.application - ERROR - Uncaught exception GET /api/v1/projects/52313ecb-9d00-4b7d-b873-b55d3d9ada26/apps/7f372516-d650-46ea-8db4-8f079a844ddd (127.0.0.1)
HTTPServerRequest(protocol='http', host='127.0.0.1:8888', method='GET', uri='/api/v1/projects/52313ecb-9d00-4b7d-b873-b55d3d9ada26/apps/7f372516-d650-46ea-8db4-8f079a844ddd', version='HTTP/1.1', remote_ip='127.0.0.1')

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/tornado/web.py", line 1701, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "/home/ubuntu/empower-runtime/empower/managers/apimanager/apimanager.py", line 68, in magic
    self.write_as_json(output)
  File "/home/ubuntu/empower-runtime/empower/managers/apimanager/apimanager.py", line 271, in write_as_json
    self.write(json.dumps(serialize(value), indent=4))
  File "/usr/lib/python3.6/functools.py", line 807, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/home/ubuntu/empower-runtime/empower/core/serialize.py", line 81, in _
    return serialize(obj.to_dict())
  File "/home/ubuntu/empower-runtime/empower/core/service.py", line 176, in to_dict
    output['manifest'] = self.manifest
  File "/home/ubuntu/empower-runtime/empower/core/service.py", line 196, in manifest
    return self.context.manager.catalog[self.name]
  File "/home/ubuntu/empower-runtime/empower/managers/projectsmanager/projectsmanager.py", line 63, in catalog
    return walk_module(empower.apps)
  File "/home/ubuntu/empower-runtime/empower/core/walkmodule.py", line 32, in walk_module
    __import__(package.__name__ + "." + module_name)
ModuleNotFoundError: No module named 'empower.apps.test.__main__'

2020-03-23 08:54:50,589 - tornado.access - ERROR - 500 GET /api/v1/projects/52313ecb-9d00-4b7d-b873-b55d3d9ada26/apps/7f372516-d650-46ea-8db4-8f079a844ddd (127.0.0.1) 6.11ms 
```

The reason for this is that Python tries to import from the global python packages (/usr/lib/python3.6/test instead of /home/ubuntu/empower-runtime/empower/apps). The same issue exists for all empower applications named after folders in /usr/lib/python3.6.