### PR TITLE
Update create_project.py

### DIFF
--- a/empower/cli/projects_commands/create_project.py
+++ b/empower/cli/projects_commands/create_project.py
@@ -72,7 +72,7 @@ def do_cmd(gargs, args, _):
             "ssid": args.ssid
         }
 
-    if args.mcc and args.plmnid:
+    if args.plmnid:
 
         plmnid = PLMNID(args.plmnid)
 


### PR DESCRIPTION
Removed check for args.mcc in line 75. This prevents a user from creating an LTE project in CLI as there is not a way to provide this with the given args. 

After removal, the CLI (`./empower-ctl.py create-project -c 99898 -d test -o foo`) for creating projects works as expected and can be verified in the GUI