### PR TITLE
Update lteworker.py

### DIFF
--- a/empower/managers/ranmanager/vbsp/lteworker.py
+++ b/empower/managers/ranmanager/vbsp/lteworker.py
@@ -47,7 +47,7 @@ class ELTEWorker(EWorker):
     def vbses(self):
         """Return the VBSes available to this app."""
 
-        return srv_or_die("vbspmanager").vbses
+        return srv_or_die("vbspmanager").devices
 
     @property
     def users(self):


### PR DESCRIPTION
MAC PRB Utilization Reports raises an AttributeError upon launch. This change allows the MAC PRB Utilization Reports to run without raising an exception.